### PR TITLE
Fix login context use

### DIFF
--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 export default function Login() {
   const navigate = useNavigate();
+  const { setToken } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -12,12 +14,12 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post("http://localhost:5000/api/auth/login", {
+      const res = await axios.post("/api/auth/login", {
         email,
         password,
       });
       localStorage.setItem("token", res.data.token);
-      localStorage.setItem("token", res.data.token);
+      setToken(res.data.token);
       navigate("/dashboard");
       alert("Login successful!");
     } catch (err) {


### PR DESCRIPTION
## Summary
- use `useAuth` in login page
- remove duplicate token write
- send auth requests to `/api/auth/login`
- update auth context on successful login

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851c7fb2e90832b8e95ce5b6c34835a