### PR TITLE
Fix logout to clear auth context

### DIFF
--- a/frontend/src/components/AddAssetModal.jsx
+++ b/frontend/src/components/AddAssetModal.jsx
@@ -36,6 +36,7 @@ function AddAssetModal({ onClose, onAdd }) {
       });
       onAdd(res.data);
     } catch (err) {
+      console.error(err);
       setError('❌ Failed to create asset.');
     }
   };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,10 +1,12 @@
 import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 export default function Navbar() {
   const navigate = useNavigate();
+  const { setToken } = useAuth();
 
   const handleLogout = () => {
-    localStorage.removeItem("token");
+    setToken(null);
     navigate("/login");
   };
 


### PR DESCRIPTION
## Summary
- import `useAuth` in `Navbar`
- clear auth context and redirect on logout
- fix lint error in `AddAssetModal`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851ed94ce84832bad9cebe65c25e51c