### PR TITLE
Fix frontend API urls and login token handling

### DIFF
--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 export default function Login() {
   const navigate = useNavigate();
+  const { setToken } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -12,12 +14,11 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post("http://localhost:5000/api/auth/login", {
+      const res = await axios.post("/api/auth/login", {
         email,
         password,
       });
-      localStorage.setItem("token", res.data.token);
-      localStorage.setItem("token", res.data.token);
+      setToken(res.data.token);
       navigate("/dashboard");
       alert("Login successful!");
     } catch (err) {

--- a/frontend/src/services/assetService.js
+++ b/frontend/src/services/assetService.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_URL = "http://localhost:5000/api/assets";
+const API_URL = "/api/assets";
 
 export async function getAssets() {
   const token = localStorage.getItem("token");

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_URL = "http://localhost:5000/api/auth";
+const API_URL = "/api/auth";
 
 export async function login(email, password) {
   const response = await axios.post(`${API_URL}/login`, { email, password });


### PR DESCRIPTION
## Summary
- update login page to use API proxy path and set token in AuthContext
- switch service API base URLs to relative paths

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685233f3bfc8832b8cfce37d49272cb4